### PR TITLE
On an error situation the list view would clear itself.

### DIFF
--- a/ios/Parse Dev Day/PDDListViewController.m
+++ b/ios/Parse Dev Day/PDDListViewController.m
@@ -58,6 +58,10 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     [PDDTalk findAllInBackgroundWithBlock:^(NSArray *talks, NSError *error) {
+        if (error) {
+            NSLog(@"Error while loading data: %@", error);
+            return;
+        }
         self.rawTalks = talks;
         [self _reorderTableViewSections];
     }];


### PR DESCRIPTION
This is actually a fix I did in the XebiConSchedule app. (Bases off of this project.)

When the query would error out, all data was being cleared. To create this issue: start the app so you have cached data / kill the app / enable airplane mode / start the app and wait for the 5 network attempts to finish / all data is now gone from the screen while it's still available in the cache.
